### PR TITLE
Fix error for duplicated names in ArrowFunction paremeter list

### DIFF
--- a/jerry-core/parser/js/js-parser.c
+++ b/jerry-core/parser/js/js-parser.c
@@ -1809,7 +1809,8 @@ parser_parse_function_arguments (parser_context_t *context_p, /**< context */
     if (JERRY_UNLIKELY (context_p->lit_object.literal_p->status_flags & LEXER_FLAG_FUNCTION_ARGUMENT))
     {
 #if ENABLED (JERRY_ES2015)
-      if (context_p->status_flags & PARSER_FUNCTION_HAS_NON_SIMPLE_PARAM)
+      if (context_p->status_flags & PARSER_FUNCTION_HAS_NON_SIMPLE_PARAM ||
+          context_p->status_flags & PARSER_IS_ARROW_FUNCTION)
       {
         parser_raise_error (context_p, PARSER_ERR_DUPLICATED_ARGUMENT_NAMES);
       }

--- a/tests/jerry/es2015/arrow-function.js
+++ b/tests/jerry/es2015/arrow-function.js
@@ -156,8 +156,8 @@ must_throw ("x => {} a = 1");
 must_throw ("x => {} ? 1 : 0");
 must_throw_strict ("(package) => 0");
 must_throw_strict ("(package) => { return 5 }");
-must_throw_strict ("(x,x,x) => 0");
-must_throw_strict ("(x,x,x) => { }");
+must_throw ("(x,x,x) => 0");
+must_throw ("(x,x,x) => { }");
 
 var f = (a) => 1;
 assert(f() === 1);


### PR DESCRIPTION
As written in [ES6 14.2](https://www.ecma-international.org/ecma-262/6.0/#sec-arrow-function-definitions) - ArrowParameters should be threated as StrictFormalParameters,
which should throw Syntax Error, when there is a duplicate ([ES6 14.1.2](https://www.ecma-international.org/ecma-262/6.0/#sec-function-definitions-static-semantics-early-errors))